### PR TITLE
Fixed missing parameter for border-radius

### DIFF
--- a/less/bootstrap-colorpicker.less
+++ b/less/bootstrap-colorpicker.less
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  */
- 
+
 .colorpicker-saturation {
 	width: 100px;
 	height: 100px;
@@ -18,7 +18,7 @@
 		height: 5px;
 		width: 5px;
 		border: 1px solid #000;
-		.border-radius();
+		.border-radius(5px);
 		position: absolute;
 		top: 0;
 		left: 0;
@@ -28,7 +28,7 @@
 			height: 5px;
 			width: 5px;
 			border: 1px solid #fff;
-			.border-radius();
+			.border-radius(5px);
 		}
 	}
 }


### PR DESCRIPTION
This adds missing parameters in colorpicker.less for `border-radius` mixins.
