### PR TITLE
Fix initial emptiness

### DIFF
--- a/js/bootstrap-colorpicker.js
+++ b/js/bootstrap-colorpicker.js
@@ -196,7 +196,11 @@
         },
 
         update: function() {
-            this.color = new Color(this.isInput ? this.element.prop('value') : this.element.data('color'));
+            var color = this.isInput ? this.element.prop('value') : this.element.data('color');
+            if (typeof color === "undefined" || color === null) {
+                color = '#ffffff';
+            }
+            this.color = new Color(color);
             this.picker.find('i')
                 .eq(0).css({left: this.color.value.s * 100, top: 100 - this.color.value.b * 100}).end()
                 .eq(1).css('top', 100 * (1 - this.color.value.h)).end()


### PR DESCRIPTION
This PR fixes bug which I described earlier [here](https://github.com/xaguilars/bootstrap-colorpicker/pull/5#issuecomment-12944135). I'm just seting a default (`#ffffff`) color value in case if nothing is provided via input. 

Also there's another my commit, which provides uniform JS formatting and changes some smelling pieces of code (including drop of unused duplicated `setValue` function).
