### PR TITLE
Add control buttons to be able apply/cancel result

### DIFF
--- a/less/bootstrap-colorpicker.less
+++ b/less/bootstrap-colorpicker.less
@@ -123,3 +123,15 @@
 		}
 	}
 }
+.colorpicker-controls {
+  clear: both;
+  span {
+    cursor: pointer;
+  }
+}
+.colorpicker-accept {
+  float: left;
+}
+.colorpicker-cancel {
+  float: right;
+}


### PR DESCRIPTION
We were needing to change behavior of colorpicker, and I think that results of my work can become useful for everyone.   

Via three new options, passed to a constructor, you can show and customize colorpicker controls. Here is the defaults: 

```
showControls: true 
acceptButton: '<i class="icon-ok"></i>', 
cancelButton: '<i class="icon-remove"></i>' 
```

And it looks like that: 
![ 2013-02-08 12 36 30](https://f.cloud.github.com/assets/1201569/138764/be9bfc56-71ca-11e2-8a2c-d0f5ae65e45a.png) 

It would be great, if somebody could review this feature and propose any changes or fixes. I'm sure there are some bugs for this moment (i.e. I didn't test widget with `showControls: false`), but it's not a big problem.
