### PR TITLE
#24 fixed

### DIFF
--- a/js/bootstrap-colorpicker.js
+++ b/js/bootstrap-colorpicker.js
@@ -258,6 +258,14 @@
             this.element.trigger("destroy", [this]);
        },
 
+		setValue: function(value) {
+			this.color.setColor(value);
+			this.element.trigger({
+				type: 'changeColor',
+				color: this.color
+			});
+		},
+
         //preview color change
         previewColor: function() {
             try {


### PR DESCRIPTION
This fixes an issue when clicking outside a hidden colorpicker continuously fires hidePicker and, in turn, the input's onChange event.
