### PR TITLE
hide picker when focusout

### DIFF
--- a/js/bootstrap-colorpicker.js
+++ b/js/bootstrap-colorpicker.js
@@ -125,6 +125,7 @@
         if (this.isInput) {
             this.element.on({
                 'focus.colorpicker': $.proxy(this.show, this),
+                'focusout.colorpicker': $.proxy(this.hide, this),
                 'keyup.colorpicker': $.proxy(this.update, this)
             });
         } else if (this.component) {


### PR DESCRIPTION
unfortunately, mode component is not at all suited to the forms, this is important.

for a better integration in the forms, I wrote you an example
http://jsfiddle.net/4LZjD/2/

very nice plugin otherwise :+1: 
