### PR TITLE
dont run offset() for container

### DIFF
--- a/src/js/colorpicker.js
+++ b/src/js/colorpicker.js
@@ -171,7 +171,7 @@
                 });
             },
             reposition: function() {
-                if (this.options.inline !== false) {
+                if (this.options.inline !== false || this.options.container) {
                     return false;
                 }
                 var type = this.container && this.container[0] !== document.body ? 'position' : 'offset';


### PR DESCRIPTION
when this is positioned with a container the offsets are still provided to top and left, which will place it far from where it should be.

i was able to combine this patch with css to get it where i wanted it

.refine-search .colorpicker{
  z-index: 3;
  margin-top: 30px;
}
