### PR TITLE
Add main files to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,10 @@
 {
     "name": "mjolnic-bootstrap-colorpicker",
     "version": "2.0.1",
+    "main": [
+        "dist/css/bootstrap-colorpicker.css",
+        "dist/js/bootstrap-colorpicker.js"
+    ],
     "dependencies": {
         "jquery": "^1.10",
         "bootstrap": "^2"


### PR DESCRIPTION
I referenced unminified assets because they're much easier to debug in development. In production we're compressing them anyway.

Fixes #95.